### PR TITLE
Implement Race Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ var promise = Promise.all(array)
 var resolved = Promise.resolve(123)
 var rejected = Promise.reject(321)
 var deferred = Promise.defer()
+var race = Promise.race(array)
 ```
 
 ## run tests

--- a/extra.js
+++ b/extra.js
@@ -1,5 +1,6 @@
 var Promise = require('./index')
 Promise.all = require('./all')
+Promise.race = require('./race')
 Promise.resolve = require('./resolve')
 Promise.reject = require('./reject')
 Promise.defer = require('./defer')

--- a/race.js
+++ b/race.js
@@ -2,7 +2,7 @@ var Promise = require('./index')
 module.exports = function race (values) {
   return Promise(function (resolve, reject) {
     var counter = values && values.length
-    if (!counter) return resolve(values)
+    if (!counter) return
 
     for (var i = 0; i < counter; i++) {
       Promise.resolve(values[i]).then(resolve, reject)

--- a/race.js
+++ b/race.js
@@ -1,0 +1,11 @@
+var Promise = require('./index')
+module.exports = function race (values) {
+  return Promise(function (resolve, reject) {
+    var counter = values && values.length
+    if (!counter) return resolve(values)
+
+    for (var i = 0; i < counter; i++) {
+      Promise.resolve(values[i]).then(resolve, reject)
+    }
+  })
+}

--- a/test/test-race.js
+++ b/test/test-race.js
@@ -4,13 +4,13 @@ var Promise = require('../extra')
 
 describe('race', function () {
   describe('when called with an empty array', function () {
-    it('should return immediately', function () {
+    it('should never resolve', function () {
       var values = []
-      var result
+      var isResolved = false
       Promise.race(values).then(function (val) {
-        result = val
+        isResolved = true
       })
-      expect(result).to.eql(values)
+      expect(isResolved).to.eql(false)
     })
   })
   describe('when called with just values', function () {

--- a/test/test-race.js
+++ b/test/test-race.js
@@ -1,0 +1,64 @@
+/* globals describe it */
+var expect = require('chai').expect
+var Promise = require('../extra')
+
+describe('race', function () {
+  describe('when called with an empty array', function () {
+    it('should return immediately', function () {
+      var values = []
+      var result
+      Promise.race(values).then(function (val) {
+        result = val
+      })
+      expect(result).to.eql(values)
+    })
+  })
+  describe('when called with just values', function () {
+    it('should resolve immediately with first value', function () {
+      var values = [1, 2, 3]
+      var result
+      Promise.race(values).then(function (val) {
+        result = val
+      })
+      expect(result).to.eql(1)
+    })
+  })
+  describe('when called with a mixture of values and promises', function () {
+    it('should resolve immediately with first value', function (done) {
+      var d = Promise.defer()
+      var values = [1, 2, Promise.resolve(3), d.promise]
+      Promise.race(values).then(function (val) {
+        expect(val).to.eql(1)
+        done()
+      })
+      d.resolve(4)
+    })
+  })
+  describe('when called with a mixture of promises and values with a promise at the start', function () {
+    it('should resolve immediately with first promise', function (done) {
+      var values = [Promise.resolve(1), 2]
+      Promise.race(values).then(function (val) {
+        expect(val).to.eql(1)
+        done()
+      })
+    })
+  })
+  describe('when called with only promises', function () {
+    it('should resolve immediately with first promise', function (done) {
+      var values = [Promise.resolve(1), Promise.resolve(2)]
+      Promise.race(values).then(function (val) {
+        expect(val).to.eql(1)
+        done()
+      })
+    })
+  })
+  describe('error', function () {
+    it('should reject the promise', function (done) {
+      var values = [Promise.reject('error'), 2, 3]
+      Promise.race(values).catch(function (err) {
+        expect(err).to.eql('error')
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Overview
----
* Added Promise.race() to the library to allow using it.
* Added test scripts for Promise.race()
* Updated README.md to show .race use

Use Cases
----
Using within Qubit experiences, allows developers to have two or more ways of having the experience run.

```js
Promise.race([waitForBasketSummary(), waitForBasketAdd()])
  .then(pollForMiniCart)
  .then(fire)
```

In the above example, waitForBasketSummary sets up a `options.uv.on` while waitForBasketAdd sets up an `ajaxComplete`. This allows it to run if either the uv.on fires or if the
ajaxComplete fires. Whichever happens first, but either running is fine to happen.