### PR TITLE
Any function

### DIFF
--- a/any.js
+++ b/any.js
@@ -1,0 +1,24 @@
+var promise = require('./index')
+
+module.exports = function any (values) {
+  function flip (p) {
+    return promise(function (resolve, reject) {
+      promise.resolve(p).then(reject, resolve)
+    })
+  }
+  return flip(promise(function (resolve, reject) {
+    var l
+    var counter = l = values && values.length
+    if (!counter) return reject(values)
+    for (var i = 0; i < l; i++) { loop(values[i], i) }
+    function loop (val, l) {
+      if (val && typeof val.then === 'function') {
+        return flip(val.then(reject, function decrement (val) {
+          values[l] = val
+          --counter || resolve(values)
+        }))
+      }
+      reject(val)
+    }
+  }))
+}

--- a/extra.js
+++ b/extra.js
@@ -1,5 +1,6 @@
 var Promise = require('./index')
 Promise.all = require('./all')
+Promise.any = require('./any')
 Promise.race = require('./race')
 Promise.resolve = require('./resolve')
 Promise.reject = require('./reject')

--- a/test/test-any.js
+++ b/test/test-any.js
@@ -1,0 +1,95 @@
+/* globals describe it */
+var expect = require('chai').expect
+var Promise = require('../extra')
+
+describe('any', function () {
+  describe('when called with an empty array', function () {
+    it('should return immediately', function () {
+      var values = []
+      var result
+      Promise.any(values).then(function (val) {
+        result = val
+      })
+      expect(result).to.eql(values)
+    })
+  })
+  describe('when called with just values', function () {
+    it('should return immediately', function () {
+      var values = [1, 2, 3]
+      var result
+      Promise.any(values).then(function (val) {
+        result = val
+      })
+      expect(result).to.eql(1)
+    })
+  })
+  // describe('when called with a mixture of values and promises', function () {
+  //   it('should resolve the promises and return only values', function (done) {
+  //     var d = Promise.defer()
+  //     var error = new Error('eek')
+  //     var values = [d.promise, Promise.reject(error)]
+  //     Promise.any(values).then(function (val) {
+  //       expect(val).to.eql(4)
+  //       done()
+  //     })
+  //     d.resolve(4)
+  //   })
+  // })
+  describe('when called with a mixture of values and promises', function () {
+    it('should resolve to the first value in the array', function (done) {
+      var d = Promise.defer()
+      var values = [d.promise, 2, 3]
+      Promise.any(values).then(function (val) {
+        expect(val).to.eql(2)
+        done()
+      })
+      d.resolve(1)
+    })
+  })
+  describe('when called with a mixture of values and promises that resolve and reject', function () {
+    it('should resolve returning the first value', function (done) {
+      var d = Promise.defer()
+      var e = Promise.defer()
+      var error1 = new Error('eek1')
+      var error2 = new Error('eek2')
+      var values = [d.promise, Promise.reject(error2), e.promise, 4]
+      Promise.any(values).then(function (val) {
+        expect(val).to.eql(4)
+        done()
+      })
+      d.reject(error1)
+      e.resolve(3)
+    })
+  })
+  describe('when called with a mixture of promises that resolve and reject', function () {
+    it('should resolve returning the first promise value', function (done) {
+      var d = Promise.defer()
+      var e = Promise.defer()
+      var error1 = new Error('eek1')
+      var error2 = new Error('eek2')
+      var error4 = new Error('eek4')
+      var values = [d.promise, Promise.reject(error2), e.promise, Promise.reject(error4)]
+      Promise.any(values).then(function (val) {
+        expect(val).to.eql(3)
+        done()
+      })
+      d.reject(error1)
+      e.resolve(3)
+    })
+  })
+  describe('when called with all promises that reject', function () {
+    it('should fail when all fail', function (done) {
+      var d = Promise.defer()
+      var error1 = new Error('eek1')
+      var error2 = new Error('eek2')
+      var error3 = new Error('eek3')
+      var error4 = new Error('eek4')
+      var values = [d.promise, Promise.reject(error2), Promise.reject(error3), Promise.reject(error4)]
+      Promise.any(values).catch(function (err) {
+        expect(err).to.eql([error1, error2, error3, error4])
+        done()
+      })
+      d.reject(error1)
+    })
+  })
+})

--- a/test/test-any.js
+++ b/test/test-any.js
@@ -23,18 +23,6 @@ describe('any', function () {
       expect(result).to.eql(1)
     })
   })
-  // describe('when called with a mixture of values and promises', function () {
-  //   it('should resolve the promises and return only values', function (done) {
-  //     var d = Promise.defer()
-  //     var error = new Error('eek')
-  //     var values = [d.promise, Promise.reject(error)]
-  //     Promise.any(values).then(function (val) {
-  //       expect(val).to.eql(4)
-  //       done()
-  //     })
-  //     d.resolve(4)
-  //   })
-  // })
   describe('when called with a mixture of values and promises', function () {
     it('should resolve to the first value in the array', function (done) {
       var d = Promise.defer()


### PR DESCRIPTION
Adding `.any()` function following the spec to the proposed function:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any

- Returns the first resolved value from an array of promises
- If values are passed in, it will return the first value found
- Will not reject until all promises are rejected
- Returns an array of the promises' rejections not an AggregateError, which differs from the proposed spec: https://github.com/tc39/proposal-promise-any#why-throw-an-aggregateerror-instead-of-an-array