### PR TITLE
Add fix for isolated import + tests

### DIFF
--- a/any.js
+++ b/any.js
@@ -1,4 +1,5 @@
 var promise = require('./index')
+promise.resolve = require('./resolve')
 
 module.exports = function any (values) {
   function flip (p) {

--- a/race.js
+++ b/race.js
@@ -1,4 +1,6 @@
 var Promise = require('./index')
+Promise.resolve = require('./resolve')
+
 module.exports = function race (values) {
   return Promise(function (resolve, reject) {
     var counter = values && values.length

--- a/test/test-isolation.js
+++ b/test/test-isolation.js
@@ -1,0 +1,30 @@
+/* globals describe it beforeEach */
+var expect = require('chai').expect
+
+describe('isolation', function () {
+  const modules = ['all', 'any', 'race']
+
+  beforeEach(function () {
+    delete require.cache[require.resolve('../index')]
+  })
+
+  modules.forEach((moduleName) => {
+    describe(`when '${moduleName}' imported as 'sync-p/${moduleName}'`, function () {
+      it('should not throw error', function () {
+        delete require.cache[require.resolve(`../${moduleName}`)]
+        var func = require(`../${moduleName}`)
+
+        var values = [1, 2]
+        var error = null
+
+        func(values)
+          .then()
+          .catch(function (err) {
+            error = err
+          })
+
+        expect(error).to.not.be.instanceOf(Error)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Hello @alanclarke!

Recently I started to get this error mesage in my qubit experiences
![imgbug](https://user-images.githubusercontent.com/14248702/142461212-dc5dbb2b-cfbd-454f-a8ff-04e91e9717a2.png)
It only happens when I import the modules separately, eg.:
```js
const promise = require("sync-p");
const any = require("sync-p/any"); // or race

any([/* promises */]).then(/* ... */);
```

It makes sense because in this case the `extra` module is never invoked, so the promise reference doesn't have the `.resolve` method in any.js. This problem is not covered by current tests, since they all import promise from extra.js: `var Promise = require('../extra')`.
Also, the bug is not persistent because it doesn't throw the error sometimes. Looks like `extra.js` is invoked before (internally in qubit or other experiences) in some cases,  so it saves the reference of changed `index.js` to _require.cache_ or something.

Simple fix: since we can't use `requre("./extra")` inside race, any, or all due to circular dependency, I have to explicitly assign: `promise.resolve = require('./resolve')`.
Also, added isolation tests that clean require.cache and import modules as 'sync-p/module_name'.